### PR TITLE
Enlarge grid items in grid layout. Remove 'Skip to Content' button.

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -9,8 +9,7 @@ import {
   PageSidebar,
   SkipToContent,
   PageHeaderTools,
-  Button,
-  Text
+  Button
 } from '@patternfly/react-core';
 import { routes } from '@app/routes';
 import { Role, RoleMap } from '@app/index';
@@ -73,7 +72,7 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children, role, logout
     </Nav>
   );
   const Sidebar = <PageSidebar theme="dark" nav={Navigation} isNavOpen={isMobileView ? isNavOpenMobile : isNavOpen} />;
-  const PageSkipToContent = <SkipToContent href="#primary-app-container">Skip to Content</SkipToContent>;
+  //const PageSkipToContent = <SkipToContent href="#primary-app-container">Skip to Content</SkipToContent>;
 
   return (
     <Page
@@ -81,7 +80,7 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children, role, logout
       header={Header}
       sidebar={Sidebar}
       onPageResize={onPageResize}
-      skipToContent={PageSkipToContent}
+     // skipToContent={PageSkipToContent}
     >
       {children}
     </Page>

--- a/src/app/AppLayout/__snapshots__/applayout.test.tsx.snap
+++ b/src/app/AppLayout/__snapshots__/applayout.test.tsx.snap
@@ -95,14 +95,6 @@ exports[`AppLayout tests should render AppLayout component 1`] = `
       theme="dark"
     />
   }
-  skipToContent={
-    <SkipToContent
-      href="#primary-app-container"
-      show={false}
-    >
-      Skip to Content
-    </SkipToContent>
-  }
 >
   <span />
 </Page>

--- a/src/app/Reports/ReportsDataFilterForm.tsx
+++ b/src/app/Reports/ReportsDataFilterForm.tsx
@@ -196,34 +196,34 @@ class ReportsDataFilterForm extends React.Component<myProps, myState> {
                 <Form>
                     <div>Select a date range to view available Daily, Weekly, and Monthly reports.</div>
                     <Grid>
-                        <GridItem span={2}>
+                        <GridItem span={8}>
                             <SimpleInputGroups changeDate={this.setStartDate} dateType="StartDate" key="StartDate" />
                         </GridItem>
                     </Grid>
                     <Grid>
-                        <GridItem span={2}>
+                        <GridItem span={6}>
                             <CsvDownload data={this.state.clusterData}>Download as CSV</CsvDownload>
                         </GridItem>
                     </Grid>
                     <Grid>
-                        <GridItem span={2}>
+                        <GridItem span={8}>
                             <ReportTypeDropdown setReportType={this.setReportType} ReportType={this.state.reportType} />
                         </GridItem>
                     </Grid>
                     <Grid>
-                        <GridItem span={2}>
+                        <GridItem span={8}>
                             <ReportFrequencyDropdown setReportFrequency={this.setReportFrequency} ReportFrequency={this.state.reportFrequency} />
                         </GridItem>
                     </Grid>
                     <Grid>
                         <ActionGroup>
-                            <GridItem span={1}>
+                            <GridItem span={6}>
                                 <Button onClick={() => this.changeToggle()}>Submit</Button>
                             </GridItem>
                         </ActionGroup>
                     </Grid>
                     <Grid>
-                        <GridItem span={4} rowSpan={8}>
+                        <GridItem span={10} rowSpan={8}>
                             {this.state.isLoaded && this.renderReport()}
                             {!this.state.isLoaded && this.state.err !== null && <div>{this.state.err.toString()}</div>}
                         </GridItem>

--- a/src/app/Reports/__snapshots__/reportsDataFilterForm.test.tsx.snap
+++ b/src/app/Reports/__snapshots__/reportsDataFilterForm.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Reports Page Filter Form tests should render default Reports page filte
     </div>
     <Component>
       <Component
-        span={2}
+        span={8}
       >
         <SimpleInputGroups
           changeDate={[Function]}
@@ -19,7 +19,7 @@ exports[`Reports Page Filter Form tests should render default Reports page filte
     </Component>
     <Component>
       <Component
-        span={2}
+        span={6}
       >
         <CsvDownload
           data={null}
@@ -30,7 +30,7 @@ exports[`Reports Page Filter Form tests should render default Reports page filte
     </Component>
     <Component>
       <Component
-        span={2}
+        span={8}
       >
         <ReportTypeDropdown
           ReportType="standard"
@@ -40,7 +40,7 @@ exports[`Reports Page Filter Form tests should render default Reports page filte
     </Component>
     <Component>
       <Component
-        span={2}
+        span={8}
       >
         <ReportFrequencyDropdown
           ReportFrequency="day"
@@ -51,7 +51,7 @@ exports[`Reports Page Filter Form tests should render default Reports page filte
     <Component>
       <Component>
         <Component
-          span={1}
+          span={6}
         >
           <Component
             onClick={[Function]}
@@ -64,7 +64,7 @@ exports[`Reports Page Filter Form tests should render default Reports page filte
     <Component>
       <Component
         rowSpan={8}
-        span={4}
+        span={10}
       />
     </Component>
   </Component>

--- a/src/app/project_page/demoProjectfilterform.tsx
+++ b/src/app/project_page/demoProjectfilterform.tsx
@@ -155,31 +155,31 @@ class DemoProjectFilterForm extends React.Component<myProps, myState> {
       <React.Fragment>
         <Form>
           <Grid>
-            <GridItem span={2}>
+            <GridItem span={6}>
               <SimpleInputGroups changeDate={this.setStartDate} dateType="StartDate" key="StartDate" />
               {/* {convertDateToUTC(this.state.startDate).toISOString()} */}
             </GridItem>
-            <GridItem span={2}>
+            <GridItem span={6}>
               <SimpleInputGroups changeDate={this.setEndDate} dateType="EndDate" key="EndDate" />
             </GridItem>
           </Grid>
           <Grid>
-            <GridItem span={2}>
+            <GridItem span={6}>
               <DropdownComponent key={'startHrs'} setHrs={this.setStartHrs} Hrs={this.state.startHrs} />
             </GridItem>
-            <GridItem span={2}>
+            <GridItem span={6}>
               <DropdownComponent key={'endHrs'} setHrs={this.setEndHrs} Hrs={this.state.endHrs} />
             </GridItem>
           </Grid>
           <Grid>
             <ActionGroup>
-              <GridItem span={1}>
+              <GridItem span={6}>
                 <Button onClick={() => this.changeToggle()}>Search</Button>
               </GridItem>
             </ActionGroup>
           </Grid>
           <Grid>
-            <GridItem span={4} rowSpan={8}>
+            <GridItem span={11} rowSpan={8}>
               {/* <ProjectListTable
               changingDate={this.state.changingDate}
               renderCount={this.state.conditionalRender}


### PR DESCRIPTION
Previously, there was a ‘Skip to Content’ button which jumped to the middle of a table at the bottom of the page. I think that the functionality of this button isn’t needed or even expected from a user. (1) Removing this button from the horizontal navigation menu removes an issue which causes header elements to overlap. (2) Grid items also appeared super small in a mobile view. The items were not taking advantage of available white space, so I increased the span property on GridItem. 